### PR TITLE
update gh pages only when changes are push to main (not already when PR is opened)

### DIFF
--- a/.github/workflows/asciidoctor-ghpages.yml
+++ b/.github/workflows/asciidoctor-ghpages.yml
@@ -3,8 +3,6 @@ name: asciidoctor-ghpages
 on:
   push:
     branches: [ main ]
-  pull_request:
-    branches: [ main ]
 
 jobs:
   build:


### PR DESCRIPTION
Improvement:
* update gh pages only after changes are pushed to main branch (not already when PR is opened), so we only publish after review...